### PR TITLE
feat: Add segmented timer animation

### DIFF
--- a/config.js
+++ b/config.js
@@ -182,7 +182,8 @@ const CONFIG = {
     SELECTED_SOUND: 'TIMER_1', // 선택된 종료음
     DYNAMIC_TIMER_COUNT: true, // 동적 타이머 개수 변경 허용
     CURRENT_THEME: 'COLOR', // 현재 선택된 테마 ('COLOR' 또는 'MINIMAL')
-    SEQUENTIAL_EXECUTION: false // 순차적 실행 기본값
+    SEQUENTIAL_EXECUTION: false, // 순차적 실행 기본값
+    SEGMENTED_ANIMATION: false // 분할 애니메이션 기본값
   },
 
   // 시간 형식 설정

--- a/index.html
+++ b/index.html
@@ -150,6 +150,14 @@
                     </label>
                     <div id="sequential-desc" class="sr-only">한 타이머 종료 시 자동으로 다음 타이머 시작</div>
                 </div>
+                <div class="segmented-animation-setting">
+                    <label class="segmented-animation-label" for="segmented-animation-toggle">
+                        <input type="checkbox" id="segmented-animation-toggle" aria-describedby="segmented-animation-desc">
+                        <span class="checkmark" aria-hidden="true"></span>
+                        분할 애니메이션
+                    </label>
+                    <div id="segmented-animation-desc" class="sr-only">타이머 막대를 초 단위로 분할하여 표시</div>
+                </div>
             </div>
 
             <div class="panel-section">

--- a/styles.css
+++ b/styles.css
@@ -392,6 +392,22 @@ body {
   transform: translateZ(0); /* 하드웨어 가속 */
 }
 
+/* 타이머 세그먼트 */
+.timer-segment {
+  flex-grow: 1;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  transition: all 0.3s ease-out;
+  opacity: 1;
+  transform: scaleY(1);
+  transform-origin: bottom;
+}
+
+.timer-segment.hide {
+  opacity: 0;
+  transform: scaleY(0);
+  height: 0;
+}
+
 /* 타이머별 색상 설정 - 동적 색상 지원 */
 .timer-row[data-timer-id="0"] .timer-fill { background-color: var(--timer-1-color); }
 .timer-row[data-timer-id="1"] .timer-fill { background-color: var(--timer-2-color); }


### PR DESCRIPTION
This commit introduces a new feature that allows the timer to be displayed as a series of segments, where each segment represents one second.

Key changes:
- Added a new 'Segmented Animation' option in the 'Advanced Settings' panel.
- When enabled, the timer bar is rendered as a stack of segments.
- Every second, one segment disappears with a fade-out and shrink animation, providing a step-by-step visual countdown.
- The existing smooth animation remains the default and is used when the new option is disabled.
- The new setting is saved to localStorage and persists across sessions.
- Added a temporary Playwright script during development to verify the visual changes.